### PR TITLE
Lossen concurrent-ruby and faraday versions

### DIFF
--- a/featurehub-sdk/featurehub-sdk.gemspec
+++ b/featurehub-sdk/featurehub-sdk.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", "~> 1.1"
-  spec.add_dependency "faraday", "~> 2.3"
+  spec.add_dependency "faraday", "~> 1"
   spec.add_dependency "ld-eventsource", "~> 2.2.0"
   spec.add_dependency "murmurhash3", "~> 0.1.6"
   spec.add_dependency "sem_version", "~> 2.0.0"

--- a/featurehub-sdk/featurehub-sdk.gemspec
+++ b/featurehub-sdk/featurehub-sdk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "concurrent-ruby", "~> 1.1.10"
+  spec.add_dependency "concurrent-ruby", "~> 1.1"
   spec.add_dependency "faraday", "~> 2.3"
   spec.add_dependency "ld-eventsource", "~> 2.2.0"
   spec.add_dependency "murmurhash3", "~> 0.1.6"


### PR DESCRIPTION
I had dependency conflicts when I tried to install the sdk.
So I have made the versions less strict and it worked with me.

I'm not sure about the bigger implications of my changes, but wanted to contribute my fix.