### PR TITLE
Ensure `FeatureHubRepository#find_interceptor` returns an instance of `InterceptorValue`

### DIFF
--- a/featurehub-sdk/Gemfile.lock
+++ b/featurehub-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    featurehub-sdk (1.2.3)
+    featurehub-sdk (1.2.2)
       concurrent-ruby (~> 1.1)
       faraday (~> 2)
       ld-eventsource (~> 2.2.0)

--- a/featurehub-sdk/lib/feature_hub/sdk/feature_repository.rb
+++ b/featurehub-sdk/lib/feature_hub/sdk/feature_repository.rb
@@ -50,7 +50,7 @@ module FeatureHub
       end
 
       def find_interceptor(feature_value)
-        @interceptors.find { |interceptor| interceptor.intercepted_value(feature_value) }
+        @interceptors.filter_map { |interceptor| interceptor.intercepted_value(feature_value) }.first
       end
 
       def ready?


### PR DESCRIPTION
Hello 👋 

After registering an environment interceptor and reading a feature value, I encountered an exception **#<NoMethodError: undefined method `cast' for #<FeatureHub::Sdk::EnvironmentInterceptor:0x000000010ac9c088 @enabled=true>**  at this line: https://github.com/featurehub-io/featurehub-ruby-sdk/blob/b7f818659d4e8617f45db7eb25124cff63f2ec20/featurehub-sdk/lib/feature_hub/sdk/feature_state.rb#L113 . 

The bug is in`FeatureHubRepository#find_interceptor` as it is supposed to return an instance of `InterceptorValue`, not `ValueInterceptor`. I have updated existing spec to test real behaviour.

Gemfile.lock was outdated so I included here too.